### PR TITLE
Add comprehensive backend tests

### DIFF
--- a/Backend/src/test/java/com/schooldashboard/config/CorsConfigTest.java
+++ b/Backend/src/test/java/com/schooldashboard/config/CorsConfigTest.java
@@ -1,0 +1,33 @@
+package com.schooldashboard.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class CorsConfigTest {
+
+    @Test
+    public void corsConfigurerAddsGlobalMapping() throws Exception {
+        CorsConfig config = new CorsConfig();
+        WebMvcConfigurer configurer = config.corsConfigurer();
+        CorsRegistry registry = new CorsRegistry();
+        configurer.addCorsMappings(registry);
+
+        // use reflection to access protected method getCorsConfigurations
+        Method method = CorsRegistry.class.getDeclaredMethod("getCorsConfigurations");
+        method.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, CorsConfiguration> configs = (Map<String, CorsConfiguration>) method.invoke(registry);
+
+        assertTrue(configs.containsKey("/**"));
+        CorsConfiguration cors = configs.get("/**");
+        assertEquals("*", cors.getAllowedOrigins().get(0));
+        assertTrue(cors.getAllowedMethods().containsAll(java.util.Arrays.asList("GET","POST","PUT","DELETE","OPTIONS")));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/config/WebConfigTest.java
+++ b/Backend/src/test/java/com/schooldashboard/config/WebConfigTest.java
@@ -1,0 +1,35 @@
+package com.schooldashboard.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
+
+public class WebConfigTest {
+
+    @Test
+    public void resourceHandlerConfigured() throws Exception {
+        ResourceHandlerRegistry registry = new ResourceHandlerRegistry(new StaticApplicationContext(), new MockServletContext());
+        WebConfig config = new WebConfig();
+        config.addResourceHandlers(registry);
+
+        assertTrue(registry.hasMappingForPattern("/css/**"));
+
+        Field regField = ResourceHandlerRegistry.class.getDeclaredField("registrations");
+        regField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<ResourceHandlerRegistration> registrations = (List<ResourceHandlerRegistration>) regField.get(registry);
+        ResourceHandlerRegistration registration = registrations.get(0);
+        Field locField = ResourceHandlerRegistration.class.getDeclaredField("locationValues");
+        locField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<String> locations = (List<String>) locField.get(registration);
+        assertTrue(locations.contains("classpath:/static/css/"));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/controller/CustomErrorControllerTest.java
+++ b/Backend/src/test/java/com/schooldashboard/controller/CustomErrorControllerTest.java
@@ -1,0 +1,66 @@
+package com.schooldashboard.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.servlet.RequestDispatcher;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+public class CustomErrorControllerTest {
+    private CustomErrorController controller;
+
+    @BeforeEach
+    public void setup() {
+        controller = new CustomErrorController();
+    }
+
+    private String call(int statusCode, String path, String message, Model model) {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, statusCode);
+        req.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, path);
+        req.setAttribute(RequestDispatcher.ERROR_MESSAGE, message);
+        return controller.handleError(req, model);
+    }
+
+    @Test
+    public void returns404View() {
+        Model model = new ExtendedModelMap();
+        String view = call(404, "/missing", "not here", model);
+        assertEquals("error/404", view);
+        assertEquals("/missing", model.getAttribute("path"));
+        assertEquals(404, model.getAttribute("statusCode"));
+        assertEquals("Page Not Found", model.getAttribute("errorTitle"));
+        assertTrue(model.getAttribute("errorMessage").toString().contains("not here"));
+    }
+
+    @Test
+    public void returns500View() {
+        Model model = new ExtendedModelMap();
+        String view = call(500, "/boom", "kaboom", model);
+        assertEquals("error/500", view);
+        assertEquals(500, model.getAttribute("statusCode"));
+        assertEquals("Internal Server Error", model.getAttribute("errorTitle"));
+    }
+
+    @Test
+    public void returns403View() {
+        Model model = new ExtendedModelMap();
+        String view = call(403, "/denied", null, model);
+        assertEquals("error/403", view);
+        assertEquals("Access Denied", model.getAttribute("errorTitle"));
+        assertEquals(403, model.getAttribute("statusCode"));
+    }
+
+    @Test
+    public void returnsGeneralViewForOthers() {
+        Model model = new ExtendedModelMap();
+        String view = call(418, "/teapot", "short", model);
+        assertEquals("error/general", view);
+        assertEquals(418, model.getAttribute("statusCode"));
+        assertEquals("Unexpected Error", model.getAttribute("errorTitle"));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/controller/DSBControllerTest.java
+++ b/Backend/src/test/java/com/schooldashboard/controller/DSBControllerTest.java
@@ -1,0 +1,57 @@
+package com.schooldashboard.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.schooldashboard.service.DSBService;
+
+@WebMvcTest(DSBController.class)
+public class DSBControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DSBService dsbService;
+
+    @Test
+    public void getTimeTablesSuccess() throws Exception {
+        when(dsbService.getTimeTables()).thenReturn(Collections.singletonList("ok"));
+        mockMvc.perform(get("/api/dsb/timetables"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("[\"ok\"]"));
+    }
+
+    @Test
+    public void getTimeTablesFailure() throws Exception {
+        when(dsbService.getTimeTables()).thenThrow(new RuntimeException("fail"));
+        mockMvc.perform(get("/api/dsb/timetables"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("fail")));
+    }
+
+    @Test
+    public void getNewsSuccess() throws Exception {
+        when(dsbService.getNews()).thenReturn(Collections.singletonList("n"));
+        mockMvc.perform(get("/api/dsb/news"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("[\"n\"]"));
+    }
+
+    @Test
+    public void getNewsFailure() throws Exception {
+        when(dsbService.getNews()).thenThrow(new RuntimeException("no"));
+        mockMvc.perform(get("/api/dsb/news"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("no")));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/controller/SubstitutionControllerTest.java
+++ b/Backend/src/test/java/com/schooldashboard/controller/SubstitutionControllerTest.java
@@ -1,0 +1,40 @@
+package com.schooldashboard.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.schooldashboard.service.SubstitutionPlanService;
+
+@WebMvcTest(SubstitutionController.class)
+public class SubstitutionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubstitutionPlanService service;
+
+    @Test
+    public void getPlansSuccess() throws Exception {
+        when(service.getSubstitutionPlans()).thenReturn(Collections.singletonList(new com.schooldashboard.model.SubstitutionPlan()));
+        mockMvc.perform(get("/api/substitution/plans"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void getPlansFailure() throws Exception {
+        when(service.getSubstitutionPlans()).thenThrow(new RuntimeException("bad"));
+        mockMvc.perform(get("/api/substitution/plans"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("bad")));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/model/DailyNewsTest.java
+++ b/Backend/src/test/java/com/schooldashboard/model/DailyNewsTest.java
@@ -1,0 +1,19 @@
+package com.schooldashboard.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class DailyNewsTest {
+    @Test
+    public void gettersAndAddNewsItem() {
+        DailyNews news = new DailyNews();
+        news.setDate("today");
+        news.addNewsItem(" item1 ");
+        news.addNewsItem(" ");
+        news.addNewsItem(null);
+        assertEquals("today", news.getDate());
+        assertEquals(1, news.getNewsItems().size());
+        assertEquals("item1", news.getNewsItems().get(0));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/model/SubstitutionEntryTest.java
+++ b/Backend/src/test/java/com/schooldashboard/model/SubstitutionEntryTest.java
@@ -1,0 +1,32 @@
+package com.schooldashboard.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class SubstitutionEntryTest {
+    @Test
+    public void gettersAndSetters() {
+        SubstitutionEntry e = new SubstitutionEntry();
+        e.setClasses("A");
+        e.setPeriod("1");
+        e.setAbsent("ab");
+        e.setSubstitute("sub");
+        e.setOriginalSubject("orig");
+        e.setSubject("subj");
+        e.setNewRoom("R");
+        e.setType("t");
+        e.setComment("c");
+        e.setDate("d");
+        assertEquals("A", e.getClasses());
+        assertEquals("1", e.getPeriod());
+        assertEquals("ab", e.getAbsent());
+        assertEquals("sub", e.getSubstitute());
+        assertEquals("orig", e.getOriginalSubject());
+        assertEquals("subj", e.getSubject());
+        assertEquals("R", e.getNewRoom());
+        assertEquals("t", e.getType());
+        assertEquals("c", e.getComment());
+        assertEquals("d", e.getDate());
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/model/SubstitutionPlanTest.java
+++ b/Backend/src/test/java/com/schooldashboard/model/SubstitutionPlanTest.java
@@ -1,0 +1,20 @@
+package com.schooldashboard.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class SubstitutionPlanTest {
+    @Test
+    public void planPropertiesAndAddEntry() {
+        SubstitutionPlan plan = new SubstitutionPlan("d","t");
+        SubstitutionEntry entry = new SubstitutionEntry();
+        plan.addEntry(entry);
+        assertEquals("d", plan.getDate());
+        assertEquals("t", plan.getTitle());
+        assertEquals(1, plan.getEntries().size());
+        assertSame(entry, plan.getEntries().get(0));
+        plan.setSortPriority(2);
+        assertEquals(2, plan.getSortPriority());
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/service/DSBServiceTest.java
+++ b/Backend/src/test/java/com/schooldashboard/service/DSBServiceTest.java
@@ -1,0 +1,23 @@
+package com.schooldashboard.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+
+public class DSBServiceTest {
+    @Test
+    public void annotationsPresent() throws Exception {
+        Method getTT = DSBService.class.getDeclaredMethod("getTimeTables");
+        assertNotNull(getTT.getAnnotation(Cacheable.class));
+        Method getNews = DSBService.class.getDeclaredMethod("getNews");
+        assertNotNull(getNews.getAnnotation(Cacheable.class));
+        Method clear = DSBService.class.getDeclaredMethod("clearCache");
+        assertNotNull(clear.getAnnotation(CacheEvict.class));
+        assertNotNull(clear.getAnnotation(Scheduled.class));
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/service/SubstitutionPlanParserServiceTest.java
+++ b/Backend/src/test/java/com/schooldashboard/service/SubstitutionPlanParserServiceTest.java
@@ -1,0 +1,70 @@
+package com.schooldashboard.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import com.schooldashboard.model.SubstitutionPlan;
+import com.schooldashboard.model.SubstitutionEntry;
+import com.schooldashboard.model.DailyNews;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import com.sun.net.httpserver.HttpServer;
+
+public class SubstitutionPlanParserServiceTest {
+
+    private static HttpServer server;
+    private static String baseUrl;
+
+    private static final String HTML = "<html><div class='mon_title'>01.01.2024</div>"
+            + "<table class='info'><tr class='info'>Info1</tr><tr class='info'>Info2</tr></table>"
+            + "<h2>Nachrichten zum Tag</h2><p>News1</p><p>News2</p>"
+            + "<table class='mon_list'><tr class='list'><th>Klasse</th><th>Stunde</th><th>Bemerkung</th></tr>"
+            + "<tr class='list odd'><td>10A</td><td>1</td><td>Bem</td></tr></table></html>";
+
+    @BeforeAll
+    public static void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0),0);
+        server.createContext("/plan", e -> { e.sendResponseHeaders(200, HTML.getBytes().length); try(OutputStream os=e.getResponseBody()){ os.write(HTML.getBytes()); }});
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort() + "/plan";
+    }
+
+    @AfterAll
+    public static void stopServer() { server.stop(0); }
+
+    @Test
+    public void parseFromUrl() {
+        SubstitutionPlanParserService svc = new SubstitutionPlanParserService();
+        SubstitutionPlan plan = svc.parseSubstitutionPlanFromUrl(baseUrl);
+        assertEquals("01.01.2024", plan.getDate());
+        assertEquals("Info1 Info2", plan.getTitle());
+        assertEquals(1, plan.getEntries().size());
+        assertEquals("10A", plan.getEntries().get(0).getClasses());
+    }
+
+    @Test
+    public void parseDocumentWithoutNews() throws Exception {
+        String html = "<html><div class='mon_title'>02.02.2024</div>"
+                + "<table class='mon_list'><tr class='list'><th>Klasse</th><th>Vertreter</th></tr>"
+                + "<tr class='list odd'><td>9B</td><td>MrX</td></tr></table></html>";
+        Document doc = Jsoup.parse(html);
+        SubstitutionPlanParserService svc = new SubstitutionPlanParserService();
+        Method m = SubstitutionPlanParserService.class.getDeclaredMethod("parseDocument", Document.class);
+        m.setAccessible(true);
+        SubstitutionPlan plan = (SubstitutionPlan) m.invoke(svc, doc);
+        assertEquals("02.02.2024", plan.getDate());
+        assertTrue(plan.getNews().getNewsItems().isEmpty());
+        assertEquals(1, plan.getEntries().size());
+        assertEquals("MrX", plan.getEntries().get(0).getSubstitute());
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/service/SubstitutionPlanServiceTest.java
+++ b/Backend/src/test/java/com/schooldashboard/service/SubstitutionPlanServiceTest.java
@@ -1,0 +1,80 @@
+package com.schooldashboard.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.schooldashboard.model.SubstitutionPlan;
+import com.schooldashboard.util.DSBMobile;
+import com.schooldashboard.util.DSBMobile.TimeTable;
+
+public class SubstitutionPlanServiceTest {
+
+    private DSBService dsbService;
+    private SubstitutionPlanParserService parser;
+    private SubstitutionPlanService service;
+
+    @BeforeEach
+    public void setup() {
+        dsbService = mock(DSBService.class);
+        parser = mock(SubstitutionPlanParserService.class);
+        service = new SubstitutionPlanService(dsbService, parser);
+    }
+
+    private TimeTable tt(UUID uuid, String group, String detail) {
+        return new DSBMobile(""," ").new TimeTable(uuid, group, "", "", detail);
+    }
+
+    @Test
+    public void updateSubstitutionPlansCombinesAndSorts() {
+        UUID u1 = UUID.randomUUID();
+        UUID u2 = UUID.randomUUID();
+        List<TimeTable> tables = Arrays.asList(
+                tt(u1,"heute", "u1-1"),
+                tt(u1,"heute", "u1-2"),
+                tt(u2,"morgen", "u2")
+        );
+        when(dsbService.getTimeTables()).thenReturn(tables);
+
+        SubstitutionPlan p1 = new SubstitutionPlan("d1","t1");
+        p1.addEntry(new com.schooldashboard.model.SubstitutionEntry());
+        p1.getNews().addNewsItem("n1");
+        SubstitutionPlan p2 = new SubstitutionPlan("d1","t2");
+        p2.addEntry(new com.schooldashboard.model.SubstitutionEntry());
+        p2.getNews().addNewsItem("n1");
+        p2.getNews().addNewsItem("n2");
+        SubstitutionPlan p3 = new SubstitutionPlan("d2","t3");
+        p3.addEntry(new com.schooldashboard.model.SubstitutionEntry());
+
+        when(parser.parseSubstitutionPlanFromUrl("u1-1")).thenReturn(p1);
+        when(parser.parseSubstitutionPlanFromUrl("u1-2")).thenReturn(p2);
+        when(parser.parseSubstitutionPlanFromUrl("u2")).thenReturn(p3);
+
+        service.updateSubstitutionPlans();
+
+        List<SubstitutionPlan> result = service.getSubstitutionPlans();
+        assertEquals(2, result.size());
+        SubstitutionPlan first = result.get(0);
+        assertEquals(1, first.getSortPriority());
+        assertEquals(2, first.getEntries().size());
+        assertEquals(2, first.getNews().getNewsItems().size());
+        SubstitutionPlan second = result.get(1);
+        assertEquals(2, second.getSortPriority());
+    }
+
+    @Test
+    public void updateContinuesOnParserError() {
+        UUID u1 = UUID.randomUUID();
+        when(dsbService.getTimeTables()).thenReturn(List.of(tt(u1, "heute", "u")));
+        when(parser.parseSubstitutionPlanFromUrl("u")).thenThrow(new RuntimeException("err"));
+        service.updateSubstitutionPlans();
+        assertTrue(service.getSubstitutionPlans().isEmpty());
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/util/Base64Test.java
+++ b/Backend/src/test/java/com/schooldashboard/util/Base64Test.java
@@ -1,0 +1,41 @@
+package com.schooldashboard.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+public class Base64Test {
+
+    @Test
+    public void compressRoundTrip() throws IOException {
+        String text = "Hello World";
+        String compressed = Base64.encode(Base64.compress(text));
+        String decompressed = Base64.decompress(compressed);
+        assertEquals(text, decompressed);
+    }
+
+    @Test
+    public void encodeDecodeBytes() {
+        byte[] data = {1,2,3,4,5};
+        String encoded = Base64.encode(data);
+        byte[] decoded = Base64.decode(encoded);
+        assertTrue(Arrays.equals(data, decoded));
+    }
+
+    @Test
+    public void encodeStringAndDecode() throws IOException {
+        String text = "small";
+        String encoded = Base64.encode(text);
+        String decoded = Base64.decompress(encoded);
+        assertEquals(text, decoded);
+    }
+
+    @Test
+    public void decodeInvalidString() {
+        byte[] decoded = Base64.decode("%%%invalid%%%");
+        assertTrue(decoded.length > 0 || decoded.length == 0); // should not throw
+    }
+}

--- a/Backend/src/test/java/com/schooldashboard/util/DSBMobileTest.java
+++ b/Backend/src/test/java/com/schooldashboard/util/DSBMobileTest.java
@@ -1,0 +1,109 @@
+package com.schooldashboard.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.UUID;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+public class DSBMobileTest {
+
+    private static class MockDSBMobile extends DSBMobile {
+        private final JsonObject data;
+        MockDSBMobile(JsonObject data) { super("u","p"); this.data = data; }
+        @Override
+        public JsonObject pullData() { return data; }
+    }
+
+    private JsonObject createData() {
+        JsonObject childTable = new JsonObject();
+        childTable.addProperty("Id", UUID.randomUUID().toString());
+        childTable.addProperty("Title", "grp");
+        childTable.addProperty("Date", "2024-01-01");
+        JsonObject detailChild = new JsonObject();
+        detailChild.addProperty("Title", "t1");
+        detailChild.addProperty("Detail", "d1");
+        JsonArray childArr = new JsonArray();
+        childArr.add(detailChild);
+        childTable.add("Childs", childArr);
+
+        JsonObject root = new JsonObject();
+        JsonArray rootChilds = new JsonArray();
+        rootChilds.add(childTable);
+        root.add("Childs", rootChilds);
+
+        JsonObject planObj = new JsonObject();
+        planObj.addProperty("Title", "Pläne");
+        planObj.add("Root", root);
+        JsonArray plansChild = new JsonArray();
+        plansChild.add(planObj);
+
+        JsonObject newsItem = new JsonObject();
+        newsItem.addProperty("Id", UUID.randomUUID().toString());
+        newsItem.addProperty("Date", "2024-01-01");
+        newsItem.addProperty("Title", "n1");
+        newsItem.addProperty("Detail", "d2");
+        JsonObject newsRoot = new JsonObject();
+        JsonArray newsChilds = new JsonArray();
+        newsChilds.add(newsItem);
+        newsRoot.add("Childs", newsChilds);
+        JsonObject newsObj = new JsonObject();
+        newsObj.addProperty("Title", "News");
+        newsObj.add("Root", newsRoot);
+        plansChild.add(newsObj);
+
+        JsonObject content = new JsonObject();
+        content.addProperty("Title", "Inhalte");
+        content.add("Childs", plansChild);
+        JsonArray menu = new JsonArray();
+        menu.add(content);
+
+        JsonObject main = new JsonObject();
+        main.addProperty("Resultcode", 0);
+        main.add("ResultMenuItems", menu);
+        return main;
+    }
+
+    @Test
+    public void getTimeTablesParsesData() {
+        MockDSBMobile mobile = new MockDSBMobile(createData());
+        List<DSBMobile.TimeTable> tables = mobile.getTimeTables();
+        assertEquals(1, tables.size());
+        assertEquals("t1", tables.get(0).getTitle());
+    }
+
+    @Test
+    public void getNewsParsesData() {
+        MockDSBMobile mobile = new MockDSBMobile(createData());
+        List<DSBMobile.News> news = mobile.getNews();
+        assertEquals(1, news.size());
+        assertEquals("n1", news.get(0).getTitle());
+    }
+
+    @Test
+    public void helpersViaReflection() throws Exception {
+        DSBMobile mobile = new DSBMobile("u","p");
+        Method unescape = DSBMobile.class.getDeclaredMethod("unescapeString", String.class);
+        unescape.setAccessible(true);
+        String result = (String) unescape.invoke(mobile, "Line\\nTab\\tä");
+        assertEquals("Line\nTab\tä", result);
+
+        Method format = DSBMobile.class.getDeclaredMethod("getFormattedTime", java.util.Date.class);
+        format.setAccessible(true);
+        java.util.Date d = new java.util.Date(0);
+        String formatted = (String) format.invoke(mobile, d);
+        java.text.SimpleDateFormat f = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", java.util.Locale.ENGLISH);
+        assertEquals(f.format(d), formatted);
+
+        Method find = DSBMobile.class.getDeclaredMethod("findJsonObjectByTitle", JsonArray.class, String.class);
+        find.setAccessible(true);
+        JsonArray arr = new JsonArray();
+        JsonObject one = new JsonObject(); one.addProperty("Title","a"); arr.add(one);
+        assertEquals(one, find.invoke(mobile, arr, "a"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit tests for configuration, controllers, models, services and utils
- create HTTP server-based parser tests and reflection-based utility tests
- verify caching annotations and merging logic

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_68435b82d8688324969f6408cf854657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive unit and integration tests for configuration, controllers, models, services, and utility classes.
  - Enhanced test coverage for error handling, REST endpoints, data parsing, and utility methods.
  - Validated correct application behavior under various scenarios, including both successful and exceptional cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->